### PR TITLE
Fix for some issues preventing interoperability with openfire

### DIFF
--- a/archive.cmd
+++ b/archive.cmd
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+PKG=XML-Stream
+VERSION=1.23.cbt2
+
+git archive --format tar --prefix=$PKG-$VERSION/ HEAD | gzip > /tmp/$PKG-$VERSION.tar.gz 

--- a/lib/XML/Stream.pm
+++ b/lib/XML/Stream.pm
@@ -745,20 +745,6 @@ sub Connect
             $self->{SIDS}->{newconnection}->{myhostname} = $self->{SIDS}->{newconnection}->{derivedhostname};
         }
 
-#        if (!defined($PAC))
-#        {
-#            eval("use HTTP::ProxyAutoConfig;");
-#            if ($@)
-#            {
-#                $PAC = 0;
-#            }
-#            else
-#            {
-#                require HTTP::ProxyAutoConfig;
-#                $PAC = HTTP::ProxyAutoConfig->new();
-#            }
-#        }
-
         if ($PAC eq "0") {
             if (exists($ENV{"http_proxy"}))
             {

--- a/lib/XML/Stream.pm
+++ b/lib/XML/Stream.pm
@@ -745,19 +745,19 @@ sub Connect
             $self->{SIDS}->{newconnection}->{myhostname} = $self->{SIDS}->{newconnection}->{derivedhostname};
         }
 
-        if (!defined($PAC))
-        {
-            eval("use HTTP::ProxyAutoConfig;");
-            if ($@)
-            {
-                $PAC = 0;
-            }
-            else
-            {
-                require HTTP::ProxyAutoConfig;
-                $PAC = HTTP::ProxyAutoConfig->new();
-            }
-        }
+#        if (!defined($PAC))
+#        {
+#            eval("use HTTP::ProxyAutoConfig;");
+#            if ($@)
+#            {
+#                $PAC = 0;
+#            }
+#            else
+#            {
+#                require HTTP::ProxyAutoConfig;
+#                $PAC = HTTP::ProxyAutoConfig->new();
+#            }
+#        }
 
         if ($PAC eq "0") {
             if (exists($ENV{"http_proxy"}))

--- a/lib/XML/Stream.pm
+++ b/lib/XML/Stream.pm
@@ -2181,7 +2181,7 @@ sub SASLAnswerChallenge
         $response = $self->{SIDS}->{$sid}->{sasl}->{client}->client_step($challenge);
     }
 
-    my $response64 = MIME::Base64::encode_base64($response,"");
+    my $response64 = defined($response) ? MIME::Base64::encode_base64($response,"") : "";
     $self->SASLResponse($sid,$response64);
 }
 

--- a/lib/XML/Stream/Parser.pm
+++ b/lib/XML/Stream/Parser.pm
@@ -194,6 +194,12 @@ sub parse
     {
         my $start = index($self->{XML},"<");
 
+	# don't continue unless we have enough data to identify the prolog
+        if (length($self->{XML}) < 3) {
+            $self->{PARSING} = 0;
+            return $self->returnData(0);
+        }
+
         if ((substr($self->{XML},$start,3) eq "<?x") ||
             (substr($self->{XML},$start,3) eq "<?X"))
         {


### PR DESCRIPTION
First issue:

For some reason, openfire often produces on-the-wire writes which consist of two separate "chunks".  The first chunk is "<" and the second is the rest of the XML element.

This is handled just fine except that the code in the Parser.pm was misdetecting the XML "prolog" (e.g. "<?xml version='1.0' encoding='UTF-8'?>") if the first three characters were not received in one "chunk".  Fix this.

Second issue:

(This also requires changes in Net-XMPP which are submitted in a pull request on that project)

When SSL handshake failed, e.g. because of invalid certificates, the error was not being trapped and the code continued as if everything was fine. Now it fails correctly and grabs the error code from the IO::Socket::SSL library and makes it available for consumers.

Third issue: 
A warning is generated if the challenge to be encoded (base64) is uninitialized value. Avoid doing so.
