### PR TITLE
provide a default ssl_ca_path (fixes #19)

### DIFF
--- a/lib/XML/Stream.pm
+++ b/lib/XML/Stream.pm
@@ -220,7 +220,7 @@ sub new
     $self->{SIDS}->{default}->{ssl} = 0;
     $self->{SIDS}->{default}->{_tls} = 0;
     $self->{SIDS}->{default}->{ssl_verify} = 0x01; # verify peer by default
-    $self->{SIDS}->{default}->{ssl_ca_path} = '';
+    $self->{SIDS}->{default}->{ssl_ca_path} = '/etc/ssl/certs';
     $self->{SIDS}->{default}->{namespace} = "";
     $self->{SIDS}->{default}->{myhostname} = $fullname;
     $self->{SIDS}->{default}->{derivedhostname} = $fullname;


### PR DESCRIPTION
this is necessary as we already default to "verify peer"