### PR TITLE
Added support for connecting to SNI.  Fixes "Error 'AuthSend': [?]" when using talk.google.com

### DIFF
--- a/lib/XML/Stream.pm
+++ b/lib/XML/Stream.pm
@@ -633,6 +633,7 @@ sub Connect
     {
         my %ssl_params = (
             SSL_verify_mode => $self->{SIDS}->{newconnection}->{ssl_verify},
+            SSL_hostname => $self->{SIDS}->{newconnection}->{hostname}
         );
 
         if ( 0x00 != $self->{SIDS}->{newconnection}->{ssl_verify} )


### PR DESCRIPTION
I noticed that on one of my servers, there was a "Error 'AuthSend': [?]" error when I was using sendxmpp with talk.google.com

On the server that fails to send(Ubuntu 18.04.2).   "sendxmpp -d -v  ..."  looks like...

XML::Stream: LoadSSL: Success
XML::Stream: TLSClientProceed: ssl_sock(IO::Socket::INET=GLOB(0x55de5c563eb0))
XML::Stream: TLSClientProceed: SSL: We are secure


On another server works.  "sendxmpp -d -v ..."  looks like...

XML::Stream: LoadSSL: Success
XML::Stream: TLSClientProceed: ssl_sock(IO::Socket::SSL=GLOB(0x55f4a58df498))
XML::Stream: TLSClientProceed: SSL: We are secure


This fixes it for me.
