### PR TITLE
[PATCH] Do not die when hostname cannot be resolved.

### DIFF
--- a/lib/XML/Stream.pm
+++ b/lib/XML/Stream.pm
@@ -205,8 +205,7 @@ sub new
     XML::Stream::Tools::setup_debug($self, %args); 
 
     my $hostname = hostname();
-    my $address = gethostbyname($hostname) ||
-        die("Cannot resolve $hostname: $!");
+    my $address = gethostbyname($hostname) || "";
     my $fullname = gethostbyaddr($address,AF_INET) || $hostname;
 
     $self->debug(1,"new: hostname = ($fullname)");


### PR DESCRIPTION

In Debian we are currently applying the following patch to
XML-Stream.
We thought you might be interested in it too.

    From 6f085fab67ba07ff38284f9fb865a7eb29346460 Mon Sep 17 00:00:00 2001
    From: Thadeu Lima de Souza Cascardo <cascardo@debian.org>
    Date: Wed, 20 Jan 2021 13:02:16 -0300
    Subject: [PATCH] Do not die when hostname cannot be resolved.
    
    In case the local hostname cannot be resolved, use it instead of the
    full reverse name, as it would have been done in case the reverse would
    not work.
    
    Signed-off-by: Thadeu Lima de Souza Cascardo <cascardo@debian.org>
    Bug-Debian: https://bugs.debian.org/692311
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libxml-stream-perl/raw/master/debian/patches/0001-Do-not-die-when-hostname-cannot-be-resolved.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
