### PR TITLE
Set SSL_verifycn_name parameter to fix hostname verification

### DIFF
--- a/lib/XML/Stream.pm
+++ b/lib/XML/Stream.pm
@@ -633,6 +633,9 @@ sub Connect
     {
         my %ssl_params = (
             SSL_verify_mode => $self->{SIDS}->{newconnection}->{ssl_verify},
+            SSL_verifycn_name => $self->{SIDS}->{newconnection}->{to}
+                ? $self->{SIDS}->{newconnection}->{to}
+                : $self->{SIDS}->{newconnection}->{hostname},
         );
 
         if ( 0x00 != $self->{SIDS}->{newconnection}->{ssl_verify} )

--- a/t/tcpip2ssl.t
+++ b/t/tcpip2ssl.t
@@ -1,13 +1,13 @@
 use strict;
 use warnings;
 
-use Test::More tests=>3;
+use Test::More tests=>5;
 
 SKIP:
 {
     eval("use IO::Socket::SSL 0.81;");
-    skip "IO::Socket::SSL not installed", 2 if $@;
-    skip "No network communication allowed", 2 if ($ENV{NO_NETWORK});
+    skip "IO::Socket::SSL not installed", 4 if $@;
+    skip "No network communication allowed", 4 if ($ENV{NO_NETWORK});
 
     BEGIN{ use_ok( "XML::Stream","Tree", "Node" ); }
 
@@ -28,9 +28,22 @@ SKIP:
                                       ssl=>1,
                                       ssl_verify=>0x00,
                                       timeout=>10);
+        is( $stream->{SIDS}->{newconnection}->{ssl_params}->{SSL_verifycn_name},
+            'jabber.org', 'SSL_verifycn_name set' );
 
-        skip "Cannot create initial socket", 1 unless $stream;
+        skip "Cannot create initial socket", 2 unless $stream;
         
         ok( $stream, "converted" );
+
+        $stream->Connect(hostname=>"jabber.org",
+                         to=>'example.com',
+                         port=>5223,
+                         namespace=>"jabber:client",
+                         connectiontype=>"tcpip",
+                         ssl=>1,
+                         ssl_verify=>0x00,
+                         timeout=>10);
+        is( $stream->{SIDS}->{newconnection}->{ssl_params}->{SSL_verifycn_name},
+            'example.com', 'SSL_verifycn_name set to "to" value' );
     }
 }


### PR DESCRIPTION
IO-Socket-SSL 2.078 [reverted a "decision from 2014 to not verify hostname by default if hostname is IP address but no explicit verification scheme given"][1]. Since `start_SSL` uses `SSL_verifycn_name` or `SSL_hostname` when verifying the hostname and falls back to the IP address of the peer if neither of them are set, the hostname verification failed with newer versions of IO-Socket-SSL even if the certificate presented by the peer was valid.

Passing `SSL_verifycn_name` to `start_SSL` fixes this issue. The logic to determine the parameter value is based on my current understanding of the ["Server Certificates" section of the XMPP Core RFC][2] and thus uses the same logic that is also used in `OpenStream` to determine the 'to' address in the initial stream header.

[1]: https://github.com/noxxi/p5-io-socket-ssl/commit/c0a063b70f0a3ad033da0a51923c65bd2ff118a0
[2]: https://datatracker.ietf.org/doc/html/rfc6120#section-13.7.2.1